### PR TITLE
Step 0

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -8,14 +8,16 @@ RiskTracker::RiskTracker(float x, std::vector <Trade> trades) : totalRisk(x), pe
 
 int RiskTracker::updateRisk() {
     float runningSum = 0;
-    for (const auto &x: this->pendingTrades) {
+    for (const auto& x : this->pendingTrades) {
         if (x.side) {
             runningSum += (x.price * x.quantity);
-        } else {
+        }
+        else {
             runningSum -= (x.price * x.quantity);
         }
     }
     this->totalRisk += runningSum;
+    this->pendingTrades.clear();
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,12 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, TrackerClearTest) {
+    std::vector<Trade> trackedTrades;
+    RiskTracker riskTracker(0, trackedTrades);
+    riskTracker.addTrade(Trade(44, true, 1.6));
+    riskTracker.addTrade(Trade(44, false, 1.6));
+    riskTracker.updateRisk();
+    EXPECT_TRUE(riskTracker.pendingTrades.empty());
+}


### PR DESCRIPTION
The PR is to fix a bug in the riskTracker file where pending trades were not being cleared after the risk was updated. Found the bug when asserting that after each risk is updated, the pendingTrades vector should be empty. Perhaps adding a getter to the pendingTrades vector and making it a private member to make testing reflective of client use? But its a pretty minor detail. 