### PR TITLE
Fixed bug in Step 0.

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,6 +16,7 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
+    this->pendingTrades.clear();
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -3,7 +3,8 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-TEST(TradeRiskTrackerTest, TrackerInit) {
+TEST(TradeRiskTrackerTest, TrackerInit)
+{
     std::vector<Trade> trackedTrades;
     Trade testTrade1(7, true, 1.2);
     Trade testTrade2(7, false, 1.2);
@@ -17,9 +18,18 @@ TEST(TradeRiskTrackerTest, TrackerInit) {
     riskTracker.addTrade(testTrade3);
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 21.7, 1e-4);
+    Trade testTrade4(20, true, 1.2);
+    riskTracker.addTrade(testTrade4);
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 45.7, 1e-4);
+    Trade testTrade5(30, false, 5);
+    riskTracker.addTrade(testTrade5);
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), -104.3, 1e-4);
 }
 
-TEST(TradeRiskTrackerTest, TrackerZeroTest) {
+TEST(TradeRiskTrackerTest, TrackerZeroTest)
+{
     std::vector<Trade> trackedTrades;
     RiskTracker riskTracker(0, trackedTrades);
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);


### PR DESCRIPTION
1. The purpose of this PR is to fix a bug and update the unit tests for the TradeRiskTracker
2. I added the line TradeRiskTracker.clear() in the updateTrades method and added to the Unit test to make sure that after multiple trades the risk tracker was working as intended.
3. Old trades were getting applied every time the method was called, which was not the intended effect. By calling clear, each trade will only be applied to the risk tracker once.

I struggled with understanding how CMake works and how the Google test library works. I have experience with C++ from competitive programming, and haven't used the language in a development-based environment. I would recommend adding a short tutorial or some links about how to use these platforms.